### PR TITLE
Add get_scheme function

### DIFF
--- a/domain_utils/domain_utils.py
+++ b/domain_utils/domain_utils.py
@@ -3,6 +3,8 @@ from ipaddress import ip_address
 from tldextract import TLDExtract
 from urllib.parse import urlparse
 
+BLANK_SCHEME = 'blank'
+
 
 def _load_and_update_extractor(function):
     @wraps(function)
@@ -237,28 +239,26 @@ def get_stripped_url(url, scheme=False, drop_non_http=False, use_netloc=True, ex
         path_out=path_out,
     )
 
+
 def get_scheme(url):
 
     """
     Given an url extract from it the scheme
-    
+
     Parameters
     ----------
-    url: string 
+    url: string
         The URL from where we want to get the scheme
-    
+
     Returns
     ----------
     string
         Returns the scheme with a default of 'blank' if no schema is provided
     """
 
-    BLANK = 'blank'
-
     scheme = urlparse(url).scheme
 
     if scheme:
         return scheme
     else:
-        return BLANK
-    
+        return BLANK_SCHEME

--- a/domain_utils/domain_utils.py
+++ b/domain_utils/domain_utils.py
@@ -236,3 +236,29 @@ def get_stripped_url(url, scheme=False, drop_non_http=False, use_netloc=True, ex
         loc_out=loc_out,
         path_out=path_out,
     )
+
+def get_scheme(url):
+
+    """
+    Given an url extract from it the scheme
+    
+    Parameters
+    ----------
+    url: string 
+        The URL from where we want to get the scheme
+    
+    Returns
+    ----------
+    string
+        Returns the scheme with a default of 'blank' if no schema is provided
+    """
+
+    BLANK = 'blank'
+
+    scheme = urlparse(url).scheme
+
+    if scheme:
+        return scheme
+    else:
+        return BLANK
+    

--- a/tests/test_get_scheme.py
+++ b/tests/test_get_scheme.py
@@ -1,36 +1,40 @@
-import pytest
 from domain_utils import get_scheme
-
 
 
 def test_get_scheme_no_scheme():
     result = get_scheme("domain.net")
     assert result == 'blank'
 
+
 def test_get_scheme_file():
     result = get_scheme("file:///home/user/index.html")
     assert result == 'file'
-    
+
+
 def test_get_scheme_https():
     result = get_scheme("https://domain.net")
     assert result == 'https'
-    
+
+
 def test_get_scheme_http():
     result = get_scheme("http://domain.net")
     assert result == 'http'
-    
+
+
 def test_get_scheme_about():
     result = get_scheme("about:config")
     assert result == 'about'
+
 
 def test_get_scheme_webpack():
     result = get_scheme("webpack://index.js")
     assert result == 'webpack'
 
+
 def test_get_scheme_empty():
     result = get_scheme("")
     assert result == 'blank'
-    
+
 
 def test_get_scheme_ws():
     result = get_scheme("ws://socket")

--- a/tests/test_get_scheme.py
+++ b/tests/test_get_scheme.py
@@ -1,0 +1,37 @@
+import pytest
+from domain_utils import get_scheme
+
+
+
+def test_get_scheme_no_scheme():
+    result = get_scheme("domain.net")
+    assert result == 'blank'
+
+def test_get_scheme_file():
+    result = get_scheme("file:///home/user/index.html")
+    assert result == 'file'
+    
+def test_get_scheme_https():
+    result = get_scheme("https://domain.net")
+    assert result == 'https'
+    
+def test_get_scheme_http():
+    result = get_scheme("http://domain.net")
+    assert result == 'http'
+    
+def test_get_scheme_about():
+    result = get_scheme("about:config")
+    assert result == 'about'
+
+def test_get_scheme_webpack():
+    result = get_scheme("webpack://index.js")
+    assert result == 'webpack'
+
+def test_get_scheme_empty():
+    result = get_scheme("")
+    assert result == 'blank'
+    
+
+def test_get_scheme_ws():
+    result = get_scheme("ws://socket")
+    assert result == 'ws'


### PR DESCRIPTION
Complete request in issue https://github.com/mozilla/domain_utils/issues/15 .

I've created a new method that retrieves the scheme using urllib and uses `blank` as default if no scheme is provided. 