### PR TITLE
Fix some typos in the documentation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -77,14 +77,14 @@ Ready to contribute? Here's how to set up `domain_utils` for local development.
    Now you can make your changes locally.
 
 5. When you're done making changes, check that your changes pass flake8 and the
-   tests. 
+   tests::
 
     $ flake8 domain_utils tests
     $ python setup.py test or py.test
 
-   To get flake8, just pip install them into your env
+   To get flake8, just pip install it into your env.
 
-   To test other versions of python use conda or travis
+   To test other versions of python use conda or travis.
 
 6. Commit your changes and push your branch to GitHub::
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Use::
     # Get the port `5000`
     du.get_port('https://localhost:5000/a/path/to/a/file.html?a=1')
     # Get the scheme `wss`
-    du.get_port('wss://somedomain.example.com/a/path/to/a/ws')
+    du.get_scheme('wss://somedomain.example.com/a/path/to/a/ws')
 
 
 This package was originally extracted from

--- a/domain_utils/domain_utils.py
+++ b/domain_utils/domain_utils.py
@@ -131,12 +131,13 @@ def hostname_subparts(url, include_ps=False, **kwargs):
         The url from which to extract the hostname parts
     include_ps : boolean, optional
         If ``include_ps`` is set, the hostname slices will include the public suffix
-        For example: ``http://a.b.c.d.com/path?query#frag`` would yield:
+        For example, ``http://a.b.c.d.com/path?query#frag`` would yield:
 
         * ``["a.b.c.d.com", "b.c.d.com", "c.d.com", "d.com"]`` if ``include_ps == False``
         * ``["a.b.c.d.com", "b.c.d.com", "c.d.com", "d.com", "com"]`` if ``include_ps == True``
     kwargs:
-        Additionally all kwargs for get_etld1, can be passed to this method.
+        Additionally, all kwargs for ``get_etld1`` can be passed to this
+        method.
 
     Returns
     -------
@@ -204,7 +205,7 @@ def stem_url(
     ``http``, ``https``, ``ws`` and ``wss``. Websocket schemes can be omitted using
     the ``parse_ws`` parameter. Additionally, the ``scheme_default`` parameter
     provides a scheme where the url doesn't contain one. The default is ``http``
-    and so urls without a scheme will, by default, be considered as http and therfore
+    and so urls without a scheme will, by default, be considered as http and therefore
     parsed.
 
     What is returned for unparsed urls is determined by the ``return_unparsed``
@@ -293,7 +294,7 @@ def get_stripped_url(url, **kwargs):
 
 def get_scheme(url, no_scheme=NO_SCHEME):
     """
-    Given an url, extract from it the scheme.
+    Given a url, extract from it the scheme.
 
     Parameters
     ----------
@@ -306,7 +307,8 @@ def get_scheme(url, no_scheme=NO_SCHEME):
     Returns
     -------
     string
-        Returns the scheme with a default of 'blank' if no schema is provided
+        Returns the scheme with a default of ``no_scheme`` if no scheme
+        is provided
     """
 
     scheme = urlparse(url).scheme
@@ -320,12 +322,12 @@ def get_scheme(url, no_scheme=NO_SCHEME):
 @_load_and_update_extractor
 def get_port(url, extractor=None):
     """
-    Given an url, extract from it port if present.
+    Given a url, extract from it the port if present.
 
     Parameters
     ----------
     url: string
-        The URL from where we want to get the scheme
+        The URL from where we want to get the port
     extractor : tldextract::TLDExtract, optional
         An (optional) tldextract::TLDExtract instance can be passed with
         keyword `extractor`, otherwise we create and update one automatically.


### PR DESCRIPTION
Hi all,
This PR fixes a couple of minor typos I stumbled upon while reading `README.rst`, `CONTRIBUTING.rst` and the docstrings of `domain_utils.py`.